### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     name: Build and Release
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/im7mortal/unrpa/security/code-scanning/1](https://github.com/im7mortal/unrpa/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job in `.github/workflows/release.yml`, with the minimum required scope. For this job, `contents: read` is the correct least-privilege baseline (needed for checkout and reading repository content). Keep existing `deploy` job permissions unchanged, since they are already correctly scoped for Pages deployment.

Edit region: under `jobs.build` (around lines 10–12), insert:

```yml
permissions:
  contents: read
```

between `name` and `runs-on` (or before steps). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
